### PR TITLE
Add tips to use the --details option

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -22,7 +22,7 @@ After installing Enlightn, you may publish its assets using the vendor:publish A
 php artisan vendor:publish --tag=enlightn
 ```
 
-:::tip Enlight Pro
+:::tip Enlightn Pro
 
 If you are installing Enlightn Pro, you do not need to install Enlightn and you may skip the above steps as Enlightn Pro already pulls in Enlightn as a dependency for you.
 :::

--- a/reliability/dead-code-analyzer.md
+++ b/reliability/dead-code-analyzer.md
@@ -30,6 +30,10 @@ function exampleFn(array $a) {
 
 In the example code above, the highlighted line is a no-op because it is iterating over an empty array every time.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 To fix this issue, you can delete all unreachable or dead code to improve code readability.

--- a/reliability/foreach-iterable-analyzer.md
+++ b/reliability/foreach-iterable-analyzer.md
@@ -38,6 +38,10 @@ Here, depending on the return value of the `doFoo` function, the `$arrayOrFalse`
 
 There may be a small percentage of "false positives" where a condition may always be true or false, making the variable iterable at all times. In such situations, you may ignore this analyzer. 
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 This analyzer displays the files and lines of code where the possible bugs may be. You would need to evaluate whether your code actually contains a bug and fix it accordingly.

--- a/reliability/invalid-function-call-analyzer.md
+++ b/reliability/invalid-function-call-analyzer.md
@@ -20,6 +20,10 @@ function bar($foo, $bar)
 }
 ```
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 The analyzer highlights the files and lines of code where these bugs may appear. To fix them, you should confirm the following:

--- a/reliability/invalid-import-analyzer.md
+++ b/reliability/invalid-import-analyzer.md
@@ -18,6 +18,10 @@ use const Uses\MY_CONSTANT;
 
 If this constant does not exist or the namespace used in the "use" statement is incorrect, the analyzer will result in a failure.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 Make sure that there is no typo in the namespace or the structure you are importing.

--- a/reliability/invalid-method-call-analyzer.md
+++ b/reliability/invalid-method-call-analyzer.md
@@ -21,6 +21,10 @@ Some examples of invalid method calls include:
 7. Calling methods outside of class scope.
 8. Method signature mismatch.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 The analyzer highlights the files and lines of code where these bugs may appear. To fix them, you need to make sure that the method exists, is accessible within the scope, and the call matches the method signature.

--- a/reliability/invalid-method-override-analyzer.md
+++ b/reliability/invalid-method-override-analyzer.md
@@ -16,6 +16,10 @@ Some examples of invalid method overrides include:
 2. Non-static methods overriding static methods or vice versa.
 3. Method overrides do not match original method signature.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 The analyzer highlights the files and lines of code where these bugs may appear. To fix them, you need to make sure that the method override signature matches the original method signature and you are not overriding final methods.

--- a/reliability/invalid-offset-analyzer.md
+++ b/reliability/invalid-offset-analyzer.md
@@ -16,6 +16,10 @@ Some examples of invalid offsets include:
 2. Trying to access offsets that do not exist.
 3. Offset type mismatch.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 The analyzer highlights the files and lines of code where these bugs may appear. To fix them, make sure there are no invalid offsets based on the examples listed above.

--- a/reliability/invalid-property-access-analyzer.md
+++ b/reliability/invalid-property-access-analyzer.md
@@ -15,6 +15,10 @@ Some examples of such code include:
 1. Trying to access undefined class properties (this is a good practice but not required).
 2. Trying to access properties that are inaccessible based on scope (e.g. accessing a private property outside the class scope).
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 It may not be mandatory to "fix" or change the code. If you are referencing undefined class properties, you may define them as a matter of good practice. However, if you are referencing inaccessible properties, you would definitely need to fix your code by removing such references.

--- a/reliability/invalid-return-type-analyzer.md
+++ b/reliability/invalid-return-type-analyzer.md
@@ -17,6 +17,10 @@ Some examples of such code include:
 
 Since PHP is a loosely typed language, some of the return types may be derived by the docblock and it could happen that your code is correct but your docblock may be incorrect for some of the errors highlighted by this analyzer.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 Make sure that the return types of your methods and functions match the signature. If your docblock is incorrect, you may correct your docblock for these warnings to disappear.

--- a/reliability/missing-return-statement-analyzer.md
+++ b/reliability/missing-return-statement-analyzer.md
@@ -10,7 +10,11 @@
 
 This analyzer scans your application code to ensure that your code does not have any missing return statements.
 
-If a return type is not explicitly defined in your method or function definition, then this analyzer considers the return type defined in the docblock. 
+If a return type is not explicitly defined in your method or function definition, then this analyzer considers the return type defined in the docblock.
+
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
 
 ## How To Fix
 

--- a/reliability/undefined-constant-analyzer.md
+++ b/reliability/undefined-constant-analyzer.md
@@ -16,6 +16,10 @@ Some examples of such code include:
 2. Trying to access a constant outside of its class scope.
 3. Trying to access a constant on an unknown class or a class that has not been imported properly.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 The analyzer highlights the files and lines of code where these bugs may appear. To fix them, make sure there are no undefined constants based on the examples listed above.

--- a/reliability/undefined-variable-analyzer.md
+++ b/reliability/undefined-variable-analyzer.md
@@ -27,6 +27,10 @@ echo (string) $definedInCases; // may be undefined
 
 In the code above, the variable `$definedInCases` may only be defined if certain conditions are met. The analyzer will also flag such situations. This may also lead to "false positives" so if that is the case, feel free to ignore the warnings or the analyzer.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 The analyzer highlights the files and lines of code where these undefined variables may appear. To fix them, make sure they are defined in advance before referencing them.

--- a/reliability/unset-analyzer.md
+++ b/reliability/unset-analyzer.md
@@ -10,6 +10,10 @@
 
 This analyzer scans your application code to ensure that your code does not try to unset undefined variables.
 
+:::tip Viewing Detailed Error Messages
+To view detailed error messages, use the `--details` option while running the `enlightn` Artisan command.
+:::
+
 ## How To Fix
 
 The analyzer highlights the files and lines of code where these bugs may appear. To fix them, make sure that unset calls are to variables that have been previously defined.


### PR DESCRIPTION
Make it easy to discover the `--details` option for easier understanding of the failed checks.