### PR TITLE
Add warning for wildcard server names

### DIFF
--- a/security/host-injection-analyzer.md
+++ b/security/host-injection-analyzer.md
@@ -18,6 +18,10 @@ If your application is behind a load balancer or reverse proxy and it does not s
 
 If you have already set the `X-Forwarded-Host` header at your reverse proxy level, you may ignore this analyzer.
 
+::: danger Wildcard Server Names
+Note that you may also be exposed to a host injection attack if trusted proxies are not setup and your server name is setup as a wildcard on your web server. This however, has more to do with an insecure web server configuration and this analyzer does not detect such situations. It is recommended to configure your web server without a wildcard server name. 
+:::
+
 ## How To Fix
 
 ### Option 1: Add the TrustHosts Middleware


### PR DESCRIPTION
This PR adds a warning for wildcard server names to the host injection analyzer docs. It clarifies that wildcard server names are not detected by the analyzer and warns against setting them up on the web server. 

Reference: https://github.com/enlightn/enlightn/issues/54.