### PR TITLE
fix UpdateTelescopeEntriesTable syntax error

### DIFF
--- a/performance/telescope-cache-hit-ratio-analyzer.md
+++ b/performance/telescope-cache-hit-ratio-analyzer.md
@@ -91,7 +91,7 @@ class UpdateTelescopeEntriesTable extends Migration
     {
         $this->schema->table('telescope_entries', function (Blueprint $table) {
             $table->json('content')->change();
-        }
+        });
     }
     
     /**
@@ -103,7 +103,7 @@ class UpdateTelescopeEntriesTable extends Migration
     {
         $this->schema->table('telescope_entries', function (Blueprint $table) {
             $table->longText('content')->change();
-        }
+        });
     }
 }
 ```


### PR DESCRIPTION
This adds a missing closing parenthesis after the schema table closure for the UpdateTelescopeEntriesTable example in the Telescope Cache Hit Ratio Analyzer page. As-is, copying this stub will introduce a syntax error.

Thank you for developing and maintaining this product! It has been very useful for my own work.